### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/odluser1384453/5638fd05-6dea-4ac6-b47c-a2a1f1974fa6/857b4d9e-600b-4c17-9e24-0fc72e13856d/_apis/work/boardbadge/e5004ec4-858c-4592-a313-61cfab130970)](https://dev.azure.com/odluser1384453/5638fd05-6dea-4ac6-b47c-a2a1f1974fa6/_boards/board/t/857b4d9e-600b-4c17-9e24-0fc72e13856d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/odluser1384453/5638fd05-6dea-4ac6-b47c-a2a1f1974fa6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.